### PR TITLE
Support wagtail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Changelog: dsd-heroku
 
 The stable 1.0 release of core django-simple-deploy is now available, and this project is at 1.0 to match that.
 
+### 1.1.0
+
+#### External changes
+
+- Supports deployment of Wagtail projects:
+    - Set `DJANGO_SETTINGS_MODULE` environment variable to `<project-name>.settings.production`.
+    - Don't set `ON_HEROKU` environment variable.
+    - Use a Wagtail-specific settings template.
+    - Settings do not need to be in a conditional block, because they're already in a production-specific file.
+- Don't assume `ALLOWED_HOSTS` has already been defined.    
+
+#### Internal changes
+
+- N/A
+
 ### 1.0.0
 
 #### External changes

--- a/dsd_heroku/platform_deployer.py
+++ b/dsd_heroku/platform_deployer.py
@@ -236,10 +236,13 @@ class PlatformDeployer:
     def _modify_settings(self):
         """Add Heroku-specific settings.
 
-        This settings block is currently the same for all users. The ALLOWED_HOSTS
-        setting should be customized.
+        DEV: The ALLOWED_HOSTS setting should be customized.
         """
-        template_path = self.templates_path / "settings.py"
+        if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
+            template_path = self.templates_path / "settings_wagtail.py"
+        else:
+            template_path = self.templates_path / "settings.py"
+
         plugin_utils.modify_settings_file(template_path)
 
     def _conclude_automate_all(self):

--- a/dsd_heroku/platform_deployer.py
+++ b/dsd_heroku/platform_deployer.py
@@ -203,6 +203,7 @@ class PlatformDeployer:
         self._set_heroku_env_var()
         self._set_debug_env_var()
         self._set_secret_key_env_var()
+        self._set_settings_module_env_var()
 
     def _add_procfile(self):
         """Add Procfile to project."""
@@ -502,6 +503,20 @@ class PlatformDeployer:
         output = plugin_utils.run_quick_command(cmd, skip_logging=True)
         plugin_utils.write_output(output)
         plugin_utils.write_output("    Set SECRET_KEY config variable.")
+
+    def _set_settings_module_env_var(self):
+        """Set the DJANGO_SETTINGS_MODULE env var if needed."""
+        # This is primarily for Wagtail projects, as signified by a settings/production.py file.
+        if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
+            plugin_utils.write_output("  Setting DJANGO_SETTINGS_MODULE environment variable...")
+
+            # Need form mysite.settings.production
+            dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:]).removesuffix(".py")
+
+            cmd = f"heroku config:set DJANGO_SETTINGS_MODULE={dotted_settings_path}"
+            output = plugin_utils.run_quick_command(cmd)
+            plugin_utils.write_output(output)
+            plugin_utils.write_output("    Set SECRET_KEY config variable.")
 
     def _generate_summary(self):
         """Generate the friendly summary, which is html for now."""

--- a/dsd_heroku/platform_deployer.py
+++ b/dsd_heroku/platform_deployer.py
@@ -463,6 +463,10 @@ class PlatformDeployer:
         """Set a config var to indicate when we're in the Heroku environment.
         This is mostly used to modify settings for the deployed project.
         """
+        # Don't need this env var for Wagtail projects.
+        if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
+            return
+            
         plugin_utils.write_output("  Setting Heroku environment variable...")
         cmd = "heroku config:set ON_HEROKU=1"
         output = plugin_utils.run_quick_command(cmd)

--- a/dsd_heroku/templates/settings.py
+++ b/dsd_heroku/templates/settings.py
@@ -9,7 +9,10 @@ if "ON_HEROKU" in os.environ:
     DEBUG = os.getenv("DEBUG") == "TRUE"
     SECRET_KEY = os.getenv("SECRET_KEY")
 
-    ALLOWED_HOSTS.append("*")
+    try:
+        ALLOWED_HOSTS.append("*")
+    except NameError:
+        ALLOWED_HOSTS = ["*"]
 
     DATABASES = {
         "default": dj_database_url.config(

--- a/dsd_heroku/templates/settings_wagtail.py
+++ b/dsd_heroku/templates/settings_wagtail.py
@@ -35,13 +35,6 @@ if "ON_HEROKU" in os.environ:
     i = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
     MIDDLEWARE.insert(i + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
 
-    # STORAGES = {
-    #     # Enable WhiteNoise's GZip and Brotli compression of static assets:
-    #     # https://whitenoise.readthedocs.io/en/latest/django.html#add-compression-and-caching-support
-    #     "staticfiles": {
-    #         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
-    #     },
-    # }
     STORAGES["staticfiles"]["BACKEND"] = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
     # Don't store the original (un-hashed filename) version of static files, to reduce slug size:

--- a/dsd_heroku/templates/settings_wagtail.py
+++ b/dsd_heroku/templates/settings_wagtail.py
@@ -1,0 +1,49 @@
+{{current_settings}}
+
+# Heroku settings.
+import os
+
+if "ON_HEROKU" in os.environ:
+    import dj_database_url
+
+    DEBUG = os.getenv("DEBUG") == "TRUE"
+    SECRET_KEY = os.getenv("SECRET_KEY")
+
+    try:
+        ALLOWED_HOSTS.append("*")
+    except NameError:
+        ALLOWED_HOSTS = ["*"]
+
+    DATABASES = {
+        "default": dj_database_url.config(
+            env="DATABASE_URL",
+            conn_max_age=600,
+            conn_health_checks=True,
+            ssl_require=True,
+        ),
+    }
+
+    STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+    STATIC_URL = "/static/"
+    try:
+        STATICFILES_DIRS.append(os.path.join(BASE_DIR, "static"))
+    except NameError:
+        STATICFILES_DIRS = [
+            os.path.join(BASE_DIR, "static"),
+        ]
+
+    i = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
+    MIDDLEWARE.insert(i + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
+
+    # STORAGES = {
+    #     # Enable WhiteNoise's GZip and Brotli compression of static assets:
+    #     # https://whitenoise.readthedocs.io/en/latest/django.html#add-compression-and-caching-support
+    #     "staticfiles": {
+    #         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    #     },
+    # }
+    STORAGES["staticfiles"]["BACKEND"] = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+    # Don't store the original (un-hashed filename) version of static files, to reduce slug size:
+    # https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_KEEP_ONLY_HASHED_FILES
+    WHITENOISE_KEEP_ONLY_HASHED_FILES = True

--- a/dsd_heroku/templates/settings_wagtail.py
+++ b/dsd_heroku/templates/settings_wagtail.py
@@ -3,40 +3,39 @@
 # Heroku settings.
 import os
 
-if "ON_HEROKU" in os.environ:
-    import dj_database_url
+import dj_database_url
 
-    DEBUG = os.getenv("DEBUG") == "TRUE"
-    SECRET_KEY = os.getenv("SECRET_KEY")
+DEBUG = os.getenv("DEBUG") == "TRUE"
+SECRET_KEY = os.getenv("SECRET_KEY")
 
-    try:
-        ALLOWED_HOSTS.append("*")
-    except NameError:
-        ALLOWED_HOSTS = ["*"]
+try:
+    ALLOWED_HOSTS.append("*")
+except NameError:
+    ALLOWED_HOSTS = ["*"]
 
-    DATABASES = {
-        "default": dj_database_url.config(
-            env="DATABASE_URL",
-            conn_max_age=600,
-            conn_health_checks=True,
-            ssl_require=True,
-        ),
-    }
+DATABASES = {
+    "default": dj_database_url.config(
+        env="DATABASE_URL",
+        conn_max_age=600,
+        conn_health_checks=True,
+        ssl_require=True,
+    ),
+}
 
-    STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
-    STATIC_URL = "/static/"
-    try:
-        STATICFILES_DIRS.append(os.path.join(BASE_DIR, "static"))
-    except NameError:
-        STATICFILES_DIRS = [
-            os.path.join(BASE_DIR, "static"),
-        ]
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+STATIC_URL = "/static/"
+try:
+    STATICFILES_DIRS.append(os.path.join(BASE_DIR, "static"))
+except NameError:
+    STATICFILES_DIRS = [
+        os.path.join(BASE_DIR, "static"),
+    ]
 
-    i = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
-    MIDDLEWARE.insert(i + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
+i = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
+MIDDLEWARE.insert(i + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
 
-    STORAGES["staticfiles"]["BACKEND"] = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES["staticfiles"]["BACKEND"] = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
-    # Don't store the original (un-hashed filename) version of static files, to reduce slug size:
-    # https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_KEEP_ONLY_HASHED_FILES
-    WHITENOISE_KEEP_ONLY_HASHED_FILES = True
+# Don't store the original (un-hashed filename) version of static files, to reduce slug size:
+# https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_KEEP_ONLY_HASHED_FILES
+WHITENOISE_KEEP_ONLY_HASHED_FILES = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dsd-heroku"
-version = "1.0.0"
+version = "1.1.0"
 description = "A plugin for django-simple-deploy, supporting deployments to Heroku."
 readme = "README.md"
 

--- a/tests/integration_tests/reference_files/settings.py
+++ b/tests/integration_tests/reference_files/settings.py
@@ -142,7 +142,10 @@ if "ON_HEROKU" in os.environ:
     DEBUG = os.getenv("DEBUG") == "TRUE"
     SECRET_KEY = os.getenv("SECRET_KEY")
 
-    ALLOWED_HOSTS.append("*")
+    try:
+        ALLOWED_HOSTS.append("*")
+    except NameError:
+        ALLOWED_HOSTS = ["*"]
 
     DATABASES = {
         "default": dj_database_url.config(


### PR DESCRIPTION
Supports deployment of Wagtail projects to Heroku:

- Set `DJANGO_SETTINGS_MODULE` environment variable to `<project-name>.settings.production`.
- Don't set `ON_HEROKU` environment variable.
- Use a Wagtail-specific settings template.
- Settings do not need to be in a conditional block, because they're already in a production-specific file.